### PR TITLE
init defaultMate before calling Newlogger

### DIFF
--- a/logrus_mate.go
+++ b/logrus_mate.go
@@ -22,9 +22,7 @@ type LogrusMate struct {
 func Logger(loggerName ...string) (logger *logrus.Logger) {
 	if defaultMate == nil {
 		defaultMateInitOnce.Do(func() {
-			if defaultMate == nil {
-				defaultMate = defaultLogrusMate()
-			}
+			defaultMate = defaultLogrusMate()
 		})
 	}
 
@@ -32,6 +30,12 @@ func Logger(loggerName ...string) (logger *logrus.Logger) {
 }
 
 func NewLogger(name string, conf LoggerConfig) (logger *logrus.Logger, err error) {
+	if defaultMate == nil {
+		defaultMateInitOnce.Do(func() {
+			defaultMate = defaultLogrusMate()
+		})
+	}
+
 	return defaultMate.NewLogger(name, conf)
 }
 


### PR DESCRIPTION
Hello, thank you for this project.
While trying to use this package I realized that if you'll call `logrus_mate.NewLogger` before calling `logrus_mate.Logger` you will get a NPE, because defaultMate, in this case will be never initialized with real value.
So you ether need to use custom `Mate`, or you need to call default logger before creating new one.

I fixed this by copying check from Logger function.
Also I've removed redundant `defaultMate == nil` checks inside `Once.Do`, because you will never get false on this.
The logic is following: if `defaultMate` is `nil` then you will call `Once.Do`, which will execute callback exactly one time, regardless of calls from different threads. If `defaultMate` is `nil`, then it will be `nil`, during the callback execution because mutex wan't allow race on this.
