### PR TITLE
Renamed all `Sirupsen` to `sirupsen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logrus Mate <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
 
-**Logrus mate** is a tool for [Logrus](https://github.com/Sirupsen/logrus), it will help you to initial logger by config, including `Formatter`, `Hook`，`Level` and `Output` .
+**Logrus mate** is a tool for [Logrus](https://github.com/sirupsen/logrus), it will help you to initial logger by config, including `Formatter`, `Hook`，`Level` and `Output` .
 
 > If you more prefer old version, you could checkout tag v1.0.0
 
@@ -14,7 +14,7 @@ Hijack `logrus.StandardLogger()`
 package main
 
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/gogap/logrus_mate"
 )
 
@@ -62,7 +62,7 @@ Hi jack logger by mate
 package main
 
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/gogap/logrus_mate"
 )
 
@@ -90,7 +90,7 @@ Fallback the ConfigString
 package main
 
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/gogap/logrus_mate"
 )
 
@@ -123,7 +123,7 @@ Fallback config while hijack
 package main
 
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/gogap/logrus_mate"
 )
 
@@ -154,8 +154,8 @@ you also could set your own config provider
 | Hook  | Options |
 | ----- | ----------- |
 | [Airbrake](https://github.com/gemnasium/logrus-airbrake-hook) | `project-id` `api-key` `env`|
-| [Syslog](https://github.com/Sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | `network` `address` `priority` `tag`|
-| [BugSnag](https://github.com/Sirupsen/logrus/blob/master/hooks/bugsnag/bugsnag.go) | `api-key` |
+| [Syslog](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go) | `network` `address` `priority` `tag`|
+| [BugSnag](https://github.com/sirupsen/logrus/blob/master/hooks/bugsnag/bugsnag.go) | `api-key` |
 | [Slackrus](https://github.com/johntdyer/slackrus) | `url` `levels` `channel` `emoji` `username`|
 | [Graylog](https://github.com/gemnasium/logrus-graylog-hook) | `address` `facility` `extra`|
 | [Mail](https://github.com/zbindenren/logrus_mail) | `app-name` `host` `port` `from` `to` `username` `password`|
@@ -342,7 +342,7 @@ type Configuration interface {
 package main
 
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/gogap/logrus_mate"
 )
 

--- a/example/main.go
+++ b/example/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gogap/errors"
 	"github.com/gogap/logrus_mate"
 

--- a/formatter_json.go
+++ b/formatter_json.go
@@ -1,7 +1,7 @@
 package logrus_mate
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type JSONFormatterConfig struct {

--- a/formatter_null.go
+++ b/formatter_null.go
@@ -1,7 +1,7 @@
 package logrus_mate
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type NullFormatter struct {

--- a/formatter_text.go
+++ b/formatter_text.go
@@ -1,7 +1,7 @@
 package logrus_mate
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/formatters.go
+++ b/formatters.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/hooks.go
+++ b/hooks.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/hooks/airbrake/airbrake.go
+++ b/hooks/airbrake/airbrake.go
@@ -1,7 +1,7 @@
 package airbrake
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/gemnasium/logrus-airbrake-hook.v2"
 
 	"github.com/gogap/logrus_mate"

--- a/hooks/bearychat/bearychat.go
+++ b/hooks/bearychat/bearychat.go
@@ -3,7 +3,7 @@ package bearychat
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gogap/bearychat"
 	"github.com/gogap/logrus_mate"
 )

--- a/hooks/bugsnag/bugsnag_hook.go
+++ b/hooks/bugsnag/bugsnag_hook.go
@@ -2,7 +2,7 @@ package bugsnag
 
 import (
 	"github.com/Shopify/logrus-bugsnag"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/bugsnag/bugsnag-go"
 
 	"github.com/gogap/logrus_mate"

--- a/hooks/expander/expander.go
+++ b/hooks/expander/expander.go
@@ -3,7 +3,7 @@ package expander
 import (
 	"github.com/gogap/errors"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gogap/logrus_mate"
 )
 

--- a/hooks/file/hook.go
+++ b/hooks/file/hook.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gogap/logrus_mate"
 
 	"github.com/gogap/logrus_mate/hooks/utils/caller"

--- a/hooks/graylog/graylog_hook.go
+++ b/hooks/graylog/graylog_hook.go
@@ -1,7 +1,7 @@
 package graylog
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/gemnasium/logrus-graylog-hook.v2"
 
 	"github.com/gogap/logrus_mate"

--- a/hooks/logstash/logstash_hook.go
+++ b/hooks/logstash/logstash_hook.go
@@ -1,7 +1,7 @@
 package logstash
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/gogap/logrus_mate"
 )

--- a/hooks/mail/mail_hook.go
+++ b/hooks/mail/mail_hook.go
@@ -1,7 +1,7 @@
 package mail
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/zbindenren/logrus_mail"
 
 	"github.com/gogap/logrus_mate"

--- a/hooks/slack/slack_hook.go
+++ b/hooks/slack/slack_hook.go
@@ -1,7 +1,7 @@
 package slack
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/johntdyer/slackrus"
 
 	"github.com/gogap/logrus_mate"

--- a/hooks/syslog/syslog_hook.go
+++ b/hooks/syslog/syslog_hook.go
@@ -3,8 +3,8 @@ package syslog
 import (
 	"log/syslog"
 
-	"github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 
 	"github.com/gogap/logrus_mate"
 )

--- a/logrus_mate.go
+++ b/logrus_mate.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/orcaman/concurrent-map"
 )
 


### PR DESCRIPTION
Getting  `case-insensitive import collision` using this lib after this change: https://github.com/sirupsen/logrus/issues/451

Still some errors, logrus-logstash-hook is misbehaving, but looks like upstream has changed more than I can fix.