### PR TITLE
rename lfshook package name

### DIFF
--- a/hooks/lfshook/lfshook.go
+++ b/hooks/lfshook/lfshook.go
@@ -1,4 +1,4 @@
-package bugsnag
+package lfshook
 
 import (
 	"fmt"


### PR DESCRIPTION
rename lfshook package name from bugsnag to lfshook