### PR TITLE
unify default log level in file hook

### DIFF
--- a/hooks/file/hook.go
+++ b/hooks/file/hook.go
@@ -52,7 +52,7 @@ func NewFileHook(config config.Configuration) (hook logrus.Hook, err error) {
 		MaxSize:    config.GetInt64("max-size", 1024),
 		RotatePerm: config.GetString("rotate-perm", "0440"),
 		Perm:       config.GetString("perm", "0660"),
-		Level:      config.GetInt32("level"),
+		Level:      config.GetInt32("level", LevelDebug),
 	}
 
 	w := newFileWriter()


### PR DESCRIPTION
hookConf 默认 level 为 0 (LevelError)，导致当使用 file hook 且 Logrus level 级别不为 error 时无法写入日志文件。

```golang
logrus_mate.Hijack(logrus.StandardLogger(), logrus_mate.ConfigString(`{ hooks { file { filename = "test.log" } }}`))

logrus.Info("this line will not write to test.log")
```